### PR TITLE
remove css limitation

### DIFF
--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -78,7 +78,3 @@ export default {
   }"
 ></component>
 ```
-
-## Limitations
-
-- During development when the `start` task is running, the browser console throws a `bundle.css` missing error.


### PR DESCRIPTION
Latest Them Lab release always builds a CSS file so no need for CSS error limitation anymore during development