### PR TITLE
escape vue data with `| escape` filter

### DIFF
--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -64,7 +64,7 @@ export default {
 
 ```liquid
 <component
-  :shopify-data="{{ product | json | replace: '"', "'" }}"
+  :shopify-data="{{ product | json | escape }}"
 ></component>
 ```
 


### PR DESCRIPTION
I've been using `replace: "'", "\\'" | replace: '"', "'"` for a while when passing data into vue, as it prevents issues caused by use of single quotes in alt tags / locale files etc, but recently discovered the ` | escape` filter in shopify. It makes the data in the dom look a little ugly with &quot; everywhere, but much simpler to write and covers a few more use cases.